### PR TITLE
Ftr/lalrpop query parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +48,15 @@ name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
 
 [[package]]
 name = "askama"
@@ -218,6 +236,21 @@ dependencies = [
  "rustc-hash",
  "shlex",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit_field"
@@ -577,13 +610,15 @@ dependencies = [
  "image",
  "indicatif",
  "itertools",
+ "lalrpop",
+ "lalrpop-util",
  "lazy_static",
  "logos",
  "lru",
  "maplit",
  "md5",
  "memmap",
- "nom",
+ "once_cell",
  "parse_wiki_text",
  "quick-xml",
  "rand",
@@ -663,6 +698,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "ena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +772,12 @@ checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1156,12 +1206,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
@@ -1250,6 +1300,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax 0.6.26",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -1556,6 +1638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,9 +1710,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "oneshot"
@@ -1777,6 +1865,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+
+[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +1944,12 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty_assertions"
@@ -1975,6 +2094,8 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax 0.6.26",
 ]
 
@@ -2311,6 +2432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2490,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "string_cache"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -2497,6 +2637,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2742,15 @@ dependencies = [
  "libc",
  "num_threads",
  "serde",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2829,6 +2989,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ flate2 = "1.0.23"
 indicatif = { version = "0.16.2", features = ["rayon"] }
 itertools = "0.10.3"
 lru = "0.7.6"
-nom = "7.1.1"
 rand = "0.8.5"
 rayon = "1.5.3"
 reqwest = { version = "0.11.10", features = ["blocking"] }
@@ -53,9 +52,14 @@ bzip2 = "0.4.3"
 parse_wiki_text = "0.1.5"
 md5 = "0.7.0"
 memmap = "0.7.0"
+lalrpop-util = { version = "0.19.8", features = ["lexer"] }
+once_cell = "1.13.1"
 
 [dev-dependencies]
 maplit = "1.0.2"
 
 [profile.release]
 debug = true
+
+[build-dependencies]
+lalrpop = "0.19.8"

--- a/build.rs
+++ b/build.rs
@@ -10,4 +10,6 @@ fn main() {
     println!("cargo:rerun-if-changed=yarn.lock");
     println!("cargo:rerun-if-changed=tailwind.config.js");
     println!("cargo:rerun-if-changed=postcss.config.js");
+
+    lalrpop::process_root().unwrap();
 }

--- a/data.tar.gz
+++ b/data.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2cabcd57754add6d968fb719d9c4e8a6d259a758995163027f7714ffec1e35d4
-size 941862585
+oid sha256:1cadc250585c97a68bdfcfda2e341c30235f3369b0c72f2ff898c3473f0417ea
+size 968695137

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 @unpack-data:
+    rm -rf data
     tar -zxvf data.tar.gz
 
 @flamegraph:

--- a/src/kv/sled_store.rs
+++ b/src/kv/sled_store.rs
@@ -16,7 +16,6 @@
 
 use std::marker::PhantomData;
 
-use nom::AsBytes;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::kv::Kv;
@@ -31,7 +30,7 @@ where
     fn get_raw(&self, key: &[u8]) -> Option<Vec<u8>> {
         self.get(key)
             .expect("failed to retrieve key")
-            .map(|v| v.as_bytes().to_vec())
+            .map(|v| v.to_vec())
     }
 
     fn insert_raw(&self, key: Vec<u8>, value: Vec<u8>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,15 @@ pub enum Error {
 
     #[error("Spell dictionary error")]
     Spell(#[from] crate::spell::dictionary::DictionaryError),
+
+    #[error("Parser error")]
+    Parse,
+}
+
+impl<L, T, E> From<lalrpop_util::ParseError<L, T, E>> for Error {
+    fn from(_: lalrpop_util::ParseError<L, T, E>) -> Self {
+        Error::Parse
+    }
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/src/query/parser.lalrpop
+++ b/src/query/parser.lalrpop
@@ -1,0 +1,12 @@
+use crate::query::Term;
+
+grammar;
+
+
+pub Terms: Vec<Term<'input>> = <Term*> => <>;
+
+Term: Term<'input> = {
+    <BasicTerm> => Term::Simple(<>),
+}
+
+BasicTerm: &'input str = r"[\S]*" => <>;

--- a/src/query/term_intersection.rs
+++ b/src/query/term_intersection.rs
@@ -20,8 +20,8 @@ use tantivy::{DocId, DocSet, Postings, Score, TERMINATED};
 
 use super::field_union::FieldUnion;
 
-const MAX_WIDTH: u32 = 45;
-const LAMBDA: f32 = 0.55;
+const MAX_WIDTH: u32 = 25;
+const LAMBDA: f32 = 0.75;
 const GAMMA: f32 = 0.25;
 
 pub fn intersect_terms(mut scorers: Vec<FieldUnion>) -> Box<dyn Scorer> {

--- a/templates/entity.html
+++ b/templates/entity.html
@@ -4,8 +4,8 @@
         {% match entity.image %}
         {% when Some(image) %}
         <div class="w-lg mb-3">
-            <a href="https://en.wikipedia.org/wiki/{{ entity.title }}">
-                <img class="h-full w-full rounded-full" src="/entity/image/{{ image }}" />
+            <a href="https://en.wikipedia.org/wiki/{{ entity.title|urlencode }}">
+                <img class="h-full w-full rounded-full" src="/entity/image/{{ image|urlencode }}" />
             </a>
         </div>
         {% when None %}
@@ -16,7 +16,8 @@
         <div class="text-sm">
             {{ entity.small_abstract }}
             <span class="italic">
-                source: <a class="text-blue-600" href="https://en.wikipedia.org/wiki/{{ entity.title }}">wikipedia</a>
+                source: <a class="text-blue-600"
+                    href="https://en.wikipedia.org/wiki/{{ entity.title|urlencode }}">wikipedia</a>
             </span>
         </div>
         {% if !entity.info.is_empty() %}
@@ -46,14 +47,15 @@
                     {% match entity.image %}
                     {% when Some(image) %}
                     <div class="h-20 w-20 mb-3">
-                        <a href="/search?q={{ entity.title }}">
-                            <img class="h-full object-cover w-full rounded-full" src="/entity/image/{{ image }}" />
+                        <a href="/search?q={{ entity.title|urlencode }}">
+                            <img class="h-full object-cover w-full rounded-full"
+                                src="/entity/image/{{ image|urlencode }}" />
                         </a>
                     </div>
                     {% when None %}
                     {% endmatch %}
                     <div class="text-center">
-                        <a href="/search?q={{ entity.title }}">
+                        <a href="/search?q={{ entity.title|urlencode }}">
                             {{ entity.title }}
                         </a>
                     </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -19,7 +19,8 @@
             {% match spell_correction %}
             {% when Some with (correction) %}
             <div class="pl-3 pb-3 ">
-                Did you mean: <a class="italic title-link font-bold" href="/search?q={{ correction }}">{{ correction
+                Did you mean: <a class="italic title-link font-bold" href="/search?q={{ correction|urlencode }}">{{
+                    correction
                     }}</a>
             </div>
             {% when None %}
@@ -31,10 +32,11 @@
                     <div class="flex flex-col w-full">
                         <div class="text-sm mb-1 flex">
                             <div class="flex items-center mr-2">
-                                <img src="/favicons/{{ item.domain }}" width="13px" />
+                                <img src="/favicons/{{ item.domain|urlencode }}" width="13px" />
                             </div>
                             <div>
-                                <a class="hover:no-underline text-gray-600" href="{{ item.url }}">{{ item.pretty_url
+                                <a class="hover:no-underline text-gray-600" href="{{ item.url|urlencode }}">{{
+                                    item.pretty_url
                                     }}</a>
                             </div>
                         </div>
@@ -56,8 +58,8 @@
                         <div class="h-20 w-20 pl-2 pt-1 pb-1">
                             {% match item.primary_image_uuid %}
                             {% when Some with (val) %}
-                            <a href="{{ item.url }}">
-                                <img class="h-full w-full object-cover rounded-full" src="/image/{{ val }}" />
+                            <a href="{{ item.url|urlencode }}">
+                                <img class="h-full w-full object-cover rounded-full" src="/image/{{ val|urlencode }}" />
                             </a>
                             {% when None %}
                             {% endmatch %}


### PR DESCRIPTION
Fix https://github.com/Cuely/Cuely/issues/10 and https://github.com/Cuely/Cuely/issues/1. The query parser has been re-written from nom to lalrpop, which will make it easier to implement the advanced query syntax mentioned in https://github.com/Cuely/Cuely/issues/2.