### PR TITLE
Optimize frontend build time

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,3 @@
-use std::process::Command;
-
 fn main() {
-    Command::new("npm")
-        .current_dir("frontend")
-        .arg("install")
-        .status()
-        .unwrap();
-
-    Command::new("npm")
-        .current_dir("frontend")
-        .args(&["run", "build"])
-        .status()
-        .unwrap();
-
     lalrpop::process_root().unwrap();
 }

--- a/justfile
+++ b/justfile
@@ -16,8 +16,16 @@
     rm -rf data/webgraph
     cargo run --release -- webgraph local configs/webgraph/local.toml
 
+@frontend-rerun:
+    # To inspect timings use the commands below instead:
+    # time ((cd frontend; npm run build) && cargo build)
+    # cargo run -- frontend data/index data/queries_us.csv data/entity data/bangs.json
+    cd frontend; npm run build
+    cargo run -- frontend data/index data/queries_us.csv data/entity data/bangs.json
+
 @frontend:
-    cargo watch -x 'run -- frontend data/index data/queries_us.csv data/entity data/bangs.json'
+    cd frontend; npm install
+    cargo watch -s 'just frontend-rerun'
 
 @astro:
     cd frontend; npm run dev


### PR DESCRIPTION
This moves building the astro frontend from `build.rs` into the `justfile`.

This streamlines the build process for the frontend astro part, and the frontend application itself by letting `cargo watch` rebuild the astro and then the Rust binary, instead of building astro in `build.rs`.

Non-conclusive results says that this improves build times from about 14s to 10s, while being more consistent and automatically rebuilding frontend on changes :)