### PR TITLE
Add astro-icons/heroicons and cleanup some styling

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^1.1.6"
+    "astro": "^1.1.6",
+    "astro-icon": "^0.7.3"
   },
   "devDependencies": {
     "@astrojs/mdx": "^0.11.1",

--- a/frontend/src/components/Footer.astro
+++ b/frontend/src/components/Footer.astro
@@ -1,3 +1,3 @@
-<div class="flex w-full justify-center items-center h-10">
+<div class="flex w-full justify-center items-center py-10">
   <a href="/privacy-and-happy-lawyers">Terms & Privacy</a>
 </div>

--- a/frontend/src/components/Header.astro
+++ b/frontend/src/components/Header.astro
@@ -1,0 +1,31 @@
+---
+import Searchbar from "./Searchbar.astro";
+import Navbar from "./Navbar.astro";
+
+export interface Props {
+  icon?: boolean;
+  searchbar?: boolean | { query: string };
+}
+
+const { icon = true, searchbar } = Astro.props;
+---
+
+<div class="flex items-center h-24 shrink-0">
+  {
+    icon && (
+      <div class="ml-14 mr-14 h-12 w-12">
+        <a href="/">
+          <img src="/assets/images/logo.svg" class="h-full w-full" />
+        </a>
+      </div>
+    )
+  }
+  {
+    searchbar && (
+      <Searchbar
+        query={typeof searchbar == "object" ? searchbar.query : void 0}
+      />
+    )
+  }
+  <Navbar />
+</div>

--- a/frontend/src/components/Hero.astro
+++ b/frontend/src/components/Hero.astro
@@ -1,0 +1,30 @@
+---
+import { Icon } from "astro-icon";
+
+type Split<T> = T extends `${infer A},${infer R}` ? A | Split<R> : T;
+type Icons =
+  | "academic-cap,adjustments,annotation,archive,arrow-circle-down,arrow-circle-left,arrow-circle-right,arrow-circle-up,arrow-down,arrow-left,arrow-narrow-down,arrow-narrow-left,arrow-narrow-right,arrow-narrow-up,arrow-right,arrow-sm-down"
+  | "arrow-sm-left,arrow-sm-right,arrow-sm-up,arrow-up,arrows-expand,at-symbol,backspace,badge-check,ban,beaker,bell,book-open,bookmark,bookmark-alt,briefcase,cake"
+  | "calculator,calendar,camera,cash,chart-bar,chart-pie,chart-square-bar,chat,chat-alt,chat-alt-2,check,check-circle,chevron-double-down,chevron-double-left,chevron-double-right,chevron-double-up"
+  | "chevron-down,chevron-left,chevron-right,chevron-up,chip,clipboard,clipboard-check,clipboard-copy,clipboard-list,clock,cloud,cloud-download,cloud-upload,code,cog,collection"
+  | "color-swatch,credit-card,cube,cube-transparent,currency-bangladeshi,currency-dollar,currency-euro,currency-pound,currency-rupee,currency-yen,cursor-click,database,desktop-computer,device-mobile,device-tablet,document"
+  | "document-add,document-download,document-duplicate,document-remove,document-report,document-search,document-text,dots-circle-horizontal,dots-horizontal,dots-vertical,download,duplicate,emoji-happy,emoji-sad,exclamation,exclamation-circle"
+  | "external-link,eye,eye-off,fast-forward,film,filter,finger-print,fire,flag,folder,folder-add,folder-download,folder-open,folder-remove,gift,globe"
+  | "globe-alt,hand,hashtag,heart,home,identification,inbox,inbox-in,information-circle,key,library,light-bulb,lightning-bolt,link,location-marker,lock-closed"
+  | "lock-open,login,logout,mail,mail-open,map,menu,menu-alt-1,menu-alt-2,menu-alt-3,menu-alt-4,microphone,minus,minus-circle,minus-sm,moon"
+  | "music-note,newspaper,office-building,paper-airplane,paper-clip,pause,pencil,pencil-alt,phone,phone-incoming,phone-missed-call,phone-outgoing,photograph,play,plus,plus-circle"
+  | "plus-sm,presentation-chart-bar,presentation-chart-line,printer,puzzle,qrcode,question-mark-circle,receipt-refund,receipt-tax,refresh,reply,rewind,rss,save,save-as,scale"
+  | "scissors,search,search-circle,selector,server,share,shield-check,shield-exclamation,shopping-bag,shopping-cart,sort-ascending,sort-descending,sparkles,speakerphone,star,status-offline"
+  | "status-online,stop,sun,support,switch-horizontal,switch-vertical,table,tag,template,terminal,thumb-down,thumb-up,ticket,translate,trash,trending-down"
+  | "trending-up,truck,upload,user,user-add,user-circle,user-group,user-remove,users,variable,video-camera,view-boards,view-grid,view-grid-add,view-list,volume-off"
+  | "volume-up,wifi,x,x-circle,zoom-in,zoom-out";
+
+export type Props = { class?: string; icon: Split<Icons>; solid?: boolean };
+---
+
+<Icon
+  class={Astro.props.class}
+  name={Astro.props.solid
+    ? `heroicons-solid:${Astro.props.icon}`
+    : `heroicons-outline:${Astro.props.icon}`}
+/>

--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -1,38 +1,22 @@
-<navbar class="flex-grow flex justify-end pr-10 space-x-10">
+---
+import { Icon } from "astro-icon";
+---
+
+<navbar class="flex-grow flex justify-end items-center pr-10 space-x-10">
   <a href="/goggles">Goggles</a>
   <a href="/about">About</a>
   <a href="https://discord.gg/BmzKHffWJM">
-    <div class="discord-logo"></div>
+    <Icon
+      title="Discord"
+      class="w-6 text-gray-500 hover:text-gray-900 transition"
+      name="simple-icons:discord"
+    />
   </a>
   <a href="https://github.com/cuely/cuely">
-    <div class="github-logo"></div>
+    <Icon
+      title="GitHub"
+      class="w-6 text-gray-500 hover:text-gray-900 transition"
+      name="simple-icons:github"
+    />
   </a>
 </navbar>
-
-<style>
-  .github-logo {
-    background-color: gray;
-    width: 22px;
-    height: 22px;
-    -webkit-mask: url(/assets/images/github.svg) no-repeat center;
-    mask: url(/assets/images/github.svg) no-repeat center;
-    mask-size: contain;
-  }
-
-  .github-logo:hover {
-    background-color: black;
-  }
-
-  .discord-logo {
-    background-color: gray;
-    width: 22px;
-    height: 22px;
-    -webkit-mask: url(/assets/images/discord.svg) no-repeat center;
-    mask: url(/assets/images/discord.svg) no-repeat center;
-    mask-size: contain;
-  }
-
-  .discord-logo:hover {
-    background-color: black;
-  }
-</style>

--- a/frontend/src/components/Searchbar.astro
+++ b/frontend/src/components/Searchbar.astro
@@ -1,4 +1,6 @@
 ---
+import Hero from "./Hero.astro";
+
 export interface Props {
   autofocus?: boolean;
   query?: string;
@@ -36,10 +38,9 @@ const { autofocus, query } = Astro.props;
       id="searchbar"
       class="absolute group bg-white top-0 grid grid-cols-[auto_1fr_auto] grid-rows-[3rem] border rounded-3xl inset-x-0 focus-within:shadow transition-shadow"
     >
-      <img
-        class="col-[1/2] row-start-1 w-5 self-center ml-5"
-        loading="lazy"
-        src="/assets/images/search.svg"
+      <Hero
+        class="col-[1/2] row-start-1 w-5 self-center ml-5 text-gray-400"
+        icon="search"
       />
       <input
         type="text"
@@ -54,12 +55,20 @@ const { autofocus, query } = Astro.props;
           type="submit"
           class="bg-transparent p-0 m-0"
           style="border: none"
+          title="Search"
         >
-          <img
-            loading="lazy"
-            src="/assets/images/arrow.svg"
-            class="h-5 cursor-pointer bg-transparent"
-          />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            class="w-7 cursor-pointer bg-transparent stroke-brand"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M8.25 4.5l7.5 7.5-7.5 7.5"></path>
+          </svg>
         </button>
       </div>
     </div>

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -37,20 +37,6 @@ const { title } = Astro.props;
         display: block;
       }
 
-      input,
-      button,
-      select,
-      textarea {
-        font-family: inherit;
-        font-size: inherit;
-        -webkit-padding: 0.4em 0;
-        padding: 0.4em;
-        margin: 0 0 0.5em 0;
-        box-sizing: border-box;
-        border: 1px solid #ccc;
-        border-radius: 2px;
-      }
-
       input:disabled {
         color: #ccc;
       }

--- a/frontend/src/layouts/Markdown.astro
+++ b/frontend/src/layouts/Markdown.astro
@@ -1,6 +1,6 @@
 ---
 import Footer from "../components/Footer.astro";
-import Navbar from "../components/Navbar.astro";
+import Header from "../components/Header.astro";
 import Layout from "../layouts/Layout.astro";
 
 export interface Props {
@@ -12,16 +12,7 @@ const { frontmatter } = Astro.props;
 
 <Layout title={frontmatter.title}>
   <div class="flex flex-col h-full w-full">
-    <div class="min-h-max w-full">
-      <header class="flex items-center w-full h-24">
-        <div class="ml-14 mr-14 w-12 h-12">
-          <a href="/">
-            <img src="/assets/images/logo.svg" class="w-full h-full" />
-          </a>
-        </div>
-        <Navbar />
-      </header>
-    </div>
+    <Header />
 
     <div class="flex flex-col w-full h-fit items-center pt-10">
       <div

--- a/frontend/src/pages/goggles.astro
+++ b/frontend/src/pages/goggles.astro
@@ -1,25 +1,13 @@
 ---
 import Footer from "../components/Footer.astro";
-import Navbar from "../components/Navbar.astro";
 import Layout from "../layouts/Layout.astro";
+import Header from "../components/Header.astro";
 import { askama } from "../askama";
 ---
 
 <Layout title="Cuely">
     <div class="flex flex-col h-full w-full">
-        <div class="min-h-max w-full">
-            <header class="flex items-center w-full h-24">
-                <div class="ml-14 mr-14 w-12 h-12">
-                    <a href="/">
-                        <img
-                            src="/assets/images/logo.svg"
-                            class="w-full h-full"
-                        />
-                    </a>
-                </div>
-                <Navbar />
-            </header>
-        </div>
+        <Header/>        
 
         <div class="flex flex-col w-full h-fit items-center pt-10">
             <div class="flex flex-col max-w-2xl">

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -1,17 +1,16 @@
 ---
 import Footer from "../components/Footer.astro";
-import Navbar from "../components/Navbar.astro";
+import Header from "../components/Header.astro";
 import Searchbar from "../components/Searchbar.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Cuely">
-  <div class="grid grid-rows-[auto_2fr_1fr_auto] h-full">
-    <header class="py-9">
-      <Navbar />
-    </header>
-
-    <div class="flex flex-col justify-center items-center">
+  <div class="grid grid-rows-[auto_1fr_auto] h-full relative">
+    <Header icon={false} />
+    <div
+      class="flex flex-col justify-center items-center absolute top-1/4 w-full"
+    >
       <div class="flex">
         <h1 class="text-5xl uppercase mb-1 text-brand">cuely</h1>
         <span class="text-gray-500">BETA</span>
@@ -22,7 +21,7 @@ import Layout from "../layouts/Layout.astro";
       <Searchbar autofocus />
     </div>
 
-    <div class="row-start-4">
+    <div class="row-start-3">
       <Footer />
     </div>
   </div>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -6,27 +6,24 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Cuely">
-  <div class="flex flex-col h-full w-full">
-    <header class="flex items-center h-24">
+  <div class="grid grid-rows-[auto_2fr_1fr_auto] h-full">
+    <header class="py-9">
       <Navbar />
     </header>
 
-    <div
-      class="flex justify-center items-center flex-col"
-      style="flex-grow: 3;"
-    >
+    <div class="flex flex-col justify-center items-center">
       <div class="flex">
-        <h1 class="text-5xl uppercase mb-1" style="color: #0b7bff">cuely</h1>
-        <span style="color: #828282">BETA</span>
+        <h1 class="text-5xl uppercase mb-1 text-brand">cuely</h1>
+        <span class="text-gray-500">BETA</span>
       </div>
 
-      <h3 class="mb-8" style="color: #828282">Completely Open Search Engine</h3>
+      <h2 class="mb-8 text-gray-500">Completely Open Search Engine</h2>
 
       <Searchbar autofocus />
     </div>
 
-    <div class="flex grow flex-col" style="flex-grow: 2;"></div>
-
-    <Footer />
+    <div class="row-start-4">
+      <Footer />
+    </div>
   </div>
 </Layout>

--- a/frontend/src/pages/search.astro
+++ b/frontend/src/pages/search.astro
@@ -1,24 +1,17 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import Searchbar from "../components/Searchbar.astro";
-import Navbar from "../components/Navbar.astro";
 import Footer from "../components/Footer.astro";
 import Entity from "../components/Entity.astro";
 import Hero from "../components/Hero.astro";
 import GoggleSelector from "../components/GoggleSelector.astro";
 import { askama } from "../askama";
+import Header from "../components/Header.astro";
 ---
 
 <Layout title="Cuely - {{ query }}">
   <main class="flex flex-col w-full">
-    <div class="flex items-center h-24 border bg-neutral-50">
-      <div class="ml-14 mr-14 w-12 h-12">
-        <a href="/">
-          <img src="/assets/images/logo.svg" class="w-full h-full" />
-        </a>
-      </div>
-      <Searchbar query={askama`query`} />
-      <Navbar />
+    <div class="border-b bg-neutral-50">
+      <Header searchbar={{ query: askama`query` }} />
     </div>
 
     <div class="flex">

--- a/frontend/src/pages/search.astro
+++ b/frontend/src/pages/search.astro
@@ -4,6 +4,7 @@ import Searchbar from "../components/Searchbar.astro";
 import Navbar from "../components/Navbar.astro";
 import Footer from "../components/Footer.astro";
 import Entity from "../components/Entity.astro";
+import Hero from "../components/Hero.astro";
 import GoggleSelector from "../components/GoggleSelector.astro";
 import { askama } from "../askama";
 ---
@@ -138,22 +139,18 @@ import { askama } from "../askama";
           <div class="flex w-full justify-center items-center pr-24 mt-5">
             {
               askama.if_(
-                "current_page == 1",
-                <div class="prev-page gray-arrow" />,
-                askama.if_(
-                  "let Some(url) = prev_page_url",
-                  <a href="{{ url }}">
-                    <div class="prev-page cuely-color-arrow" />
-                  </a>,
-                  <div class="prev-page gray-arrow" />
-                )
+                "let Some(url) = prev_page_url",
+                <a href="{{ url }}">
+                  <Hero class="change-page-active" icon="chevron-left" />
+                </a>,
+                <Hero class="change-page-inactive" icon="chevron-left" />
               )
             }
             <div class="mr-2 ml-2">
               Page {askama`current_page`}
             </div>
             <a href="{{ next_page_url }}">
-              <div class="next-page cuely-color-arrow"></div>
+              <Hero class="change-page-active" icon="chevron-right" />
             </a>
           </div>
         </div>
@@ -167,29 +164,11 @@ import { askama } from "../askama";
 </Layout>
 
 <style>
-  .prev-page {
-    width: 16px;
-    height: 16px;
-    -webkit-mask: url(/assets/images/arrow.svg) no-repeat center;
-    mask: url(/assets/images/arrow.svg) no-repeat center;
-    mask-size: contain;
-    transform: rotate(180deg);
+  .change-page-inactive {
+    @apply w-6 text-gray-500;
   }
-
-  .next-page {
-    width: 16px;
-    height: 16px;
-    -webkit-mask: url(/assets/images/arrow.svg) no-repeat center;
-    mask: url(/assets/images/arrow.svg) no-repeat center;
-    mask-size: contain;
-  }
-
-  .gray-arrow {
-    background-color: gray;
-  }
-
-  .cuely-color-arrow {
-    background-color: #0b7bff;
+  .change-page-active {
+    @apply text-brand/80 hover:text-brand w-6;
   }
 
   .title-link {


### PR DESCRIPTION
Work still to be done:
- Some icons are added dynamically, in which case the `<Hero/>` nor `<Icon/>` components can be used. Possibly `<svg><use/></svg>` can do the trick!
- Not all icons have been converted yet. Some of the ones missing, are custom, but [that is supported as well](https://github.com/natemoo-re/astro-icon/tree/main/packages/core#local-icons). The benefit of doing it this way, is that they will be inlined and optimized during build.