### PR TITLE
Control the number of segments after merge.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ mod webpage;
 #[derive(Debug, Deserialize, Clone)]
 pub struct IndexingMasterConfig {
     limit_warc_files: Option<usize>,
+    final_num_segments: Option<u32>,
     warc_source: WarcSource,
     workers: Vec<String>,
     batch_size: Option<usize>,
@@ -67,6 +68,7 @@ pub struct IndexingMasterConfig {
 #[derive(Debug, Deserialize, Clone)]
 pub struct IndexingLocalConfig {
     limit_warc_files: Option<usize>,
+    final_num_segments: Option<u32>,
     warc_source: WarcSource,
     batch_size: Option<usize>,
     webgraph_path: Option<String>,


### PR DESCRIPTION
Before, we merged all segments into a single segment. This has the benefit of reducing the disk IO during search, but has the (quite huge) problem that multi-threaded search now becomes non-trivial.

This PR implements a way for us to control how many segments the indexer should produce in the end. We would ideally like to target roughly the same number of segments as there are threads on the search server, such that each thread get's one segment each.