### PR TITLE
Ftr/sort postings by score

### DIFF
--- a/frontend/src/pages/search.astro
+++ b/frontend/src/pages/search.astro
@@ -152,9 +152,9 @@ import Header from "../components/Header.astro";
               <Hero class="change-page-active" icon="chevron-right" />
             </a>
           </div>
-          <div class="flex flex-col w-full mt-5 pl-4 pr-24">
+          <div class="flex flex-col w-full mt-7 pl-4 pr-24">
             Didn't find what you were looking for? Try on:
-            <div class="flex w-full justify-between mt-2">
+            <div class="flex w-full justify-between mt-4">
               <div class="bg-neutral-100 rounded-full py-2 px-5">
                 <a href="https://www.google.com/search?q={{ query|urlencode }}"
                   >Google</a

--- a/src/frontend/search.rs
+++ b/src/frontend/search.rs
@@ -62,7 +62,7 @@ pub struct DisplayedWebpage {
 }
 
 const MAX_PRETTY_URL_LEN: usize = 50;
-const MAX_TITLE_LEN: usize = 50;
+const MAX_TITLE_LEN: usize = 70;
 
 fn prettify_url(url: &Url) -> String {
     let mut pretty_url = url.strip_query().to_string();

--- a/src/index.rs
+++ b/src/index.rs
@@ -250,6 +250,10 @@ impl Index {
     pub fn spell_correction(&self, terms: &[String]) -> Option<String> {
         self.spell_check(terms).or_else(|| self.split_words(terms))
     }
+
+    pub fn num_segments(&self) -> usize {
+        self.inverted_index.num_segments()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/inverted_index.rs
+++ b/src/inverted_index.rs
@@ -282,6 +282,10 @@ impl InvertedIndex {
     pub fn schema(&self) -> Arc<Schema> {
         Arc::clone(&self.schema)
     }
+
+    pub fn num_segments(&self) -> usize {
+        self.tantivy_index.searchable_segments().unwrap().len()
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,9 @@ pub enum Error {
 
     #[error("String is not float")]
     ParseFloat(#[from] std::num::ParseFloatError),
+
+    #[error("Could not open inverted-index directory")]
+    Directory(#[from] tantivy::directory::error::OpenDirectoryError),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/src/ranking/goggles/mod.rs
+++ b/src/ranking/goggles/mod.rs
@@ -327,6 +327,7 @@ mod tests {
                 host_centrality: 0.0,
                 page_centrality: 0.0,
                 fetch_time_ms: 500,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -351,6 +352,7 @@ mod tests {
                 host_centrality: 0.0001,
                 page_centrality: 0.0,
                 primary_image: None,
+                pre_computed_score: 0.0,
                 fetch_time_ms: 500,
             })
             .expect("failed to insert webpage");
@@ -447,6 +449,7 @@ mod tests {
                 host_centrality: 0.0,
                 page_centrality: 0.0,
                 fetch_time_ms: 500,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -471,6 +474,7 @@ mod tests {
                 host_centrality: 0.0001,
                 page_centrality: 0.0,
                 primary_image: None,
+                pre_computed_score: 0.0,
                 fetch_time_ms: 500,
             })
             .expect("failed to insert webpage");
@@ -546,6 +550,7 @@ mod tests {
                 host_centrality: 0.0,
                 page_centrality: 0.0,
                 fetch_time_ms: 500,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -570,6 +575,7 @@ mod tests {
                 host_centrality: 0.0001,
                 page_centrality: 0.0,
                 primary_image: None,
+                pre_computed_score: 0.0,
                 fetch_time_ms: 500,
             })
             .expect("failed to insert webpage");
@@ -594,6 +600,7 @@ mod tests {
                 host_centrality: 0.0001,
                 page_centrality: 0.0,
                 primary_image: None,
+                pre_computed_score: 0.0,
                 fetch_time_ms: 500,
             })
             .expect("failed to insert webpage");

--- a/src/ranking/mod.rs
+++ b/src/ranking/mod.rs
@@ -113,6 +113,7 @@ mod tests {
                 host_centrality: 0.0,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -137,6 +138,7 @@ mod tests {
                 host_centrality: 5.0,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -179,6 +181,7 @@ mod tests {
                 host_centrality: 0.0,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -203,6 +206,7 @@ mod tests {
                 host_centrality: 0.0,
                 fetch_time_ms: 500,
                 page_centrality: 5.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -244,6 +248,7 @@ mod tests {
                 host_centrality: 0.0,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -268,6 +273,7 @@ mod tests {
                 host_centrality: 0.0,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -290,6 +296,7 @@ mod tests {
                 host_centrality: 0.003,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -332,6 +339,7 @@ mod tests {
                 host_centrality: 0.092,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -356,6 +364,7 @@ mod tests {
                 backlinks: vec![],
                 host_centrality: 0.09,
                 fetch_time_ms: 500,
+                pre_computed_score: 0.0,
                 page_centrality: 0.0,
                 primary_image: None,
             })
@@ -395,6 +404,7 @@ mod tests {
                 host_centrality: 0.0,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -429,6 +439,7 @@ mod tests {
                 host_centrality: 0.003,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
     })
             .expect("failed to insert webpage");
@@ -472,6 +483,7 @@ mod tests {
                 host_centrality: 0.0,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -493,6 +505,7 @@ mod tests {
                 backlinks: vec![],
                 host_centrality: 0.003,
                 fetch_time_ms: 500,
+                pre_computed_score: 0.0,
                 page_centrality: 0.0,
                 primary_image: None,
             })
@@ -532,6 +545,7 @@ mod tests {
                 backlinks: vec![],
                 host_centrality: 1.0,
                 fetch_time_ms: 20,
+                pre_computed_score: 0.0,
                 page_centrality: 0.0,
                 primary_image: None,
             })
@@ -556,6 +570,7 @@ mod tests {
                 host_centrality: 1.0,
                 fetch_time_ms: 20,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -580,6 +595,7 @@ mod tests {
                 host_centrality: 1.02,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");
@@ -665,6 +681,7 @@ mod tests {
                 ),
                 backlinks: vec![],
                 host_centrality: 1.0,
+                pre_computed_score: 0.0,
                 fetch_time_ms: 500,
                 page_centrality: 0.0,
                 primary_image: None,
@@ -690,6 +707,7 @@ mod tests {
                 backlinks: vec![],
                 host_centrality: 1.0,
                 fetch_time_ms: 500,
+                pre_computed_score: 0.0,
                 page_centrality: 0.0,
                 primary_image: None,
             })
@@ -714,6 +732,7 @@ mod tests {
                 backlinks: vec![],
                 host_centrality: 1.0,
                 fetch_time_ms: 500,
+                pre_computed_score: 0.0,
                 page_centrality: 0.0,
                 primary_image: None,
             })
@@ -759,6 +778,7 @@ mod tests {
                 backlinks: vec![],
                 host_centrality: 1.0,
                 fetch_time_ms: 0,
+                pre_computed_score: 0.0,
                 page_centrality: 0.0,
                 primary_image: None,
             })
@@ -784,6 +804,7 @@ mod tests {
                 host_centrality: 1.0,
                 fetch_time_ms: 5000,
                 page_centrality: 0.0,
+                pre_computed_score: 0.0,
                 primary_image: None,
             })
             .expect("failed to insert webpage");

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -204,6 +204,7 @@ mod tests {
                     host_centrality: (NUM_WEBSITES - i) as f64,
                     fetch_time_ms: 500,
                     page_centrality: 0.0,
+                    pre_computed_score: 0.0,
                     primary_image: None,
                 })
                 .expect("failed to insert webpage");

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -119,6 +119,8 @@ impl Searcher {
             }
         }
 
+        ranker = ranker.with_max_docs(10_000_000, self.index.num_segments());
+
         let webpages = self.index.search(&query, ranker.collector())?;
         let correction = self.index.spell_correction(&query.simple_terms());
 

--- a/src/webpage/mod.rs
+++ b/src/webpage/mod.rs
@@ -125,6 +125,7 @@ pub struct Webpage {
     pub host_centrality: f64,
     pub page_centrality: f64,
     pub fetch_time_ms: u64,
+    pub pre_computed_score: f64,
     pub primary_image: Option<StoredPrimaryImage>,
 }
 
@@ -139,6 +140,7 @@ impl Webpage {
             host_centrality: 0.0,
             page_centrality: 0.0,
             fetch_time_ms: 0,
+            pre_computed_score: 0.0,
             primary_image: None,
         }
     }
@@ -196,6 +198,13 @@ impl Webpage {
                 .get_field(Field::FetchTimeMs.as_str())
                 .expect("Failed to get fetch_time_ms field"),
             self.fetch_time_ms,
+        );
+
+        doc.add_f64(
+            schema
+                .get_field(Field::PreComputedScore.as_str())
+                .expect("failed to get pre_computed_score field"),
+            self.pre_computed_score,
         );
 
         let image = bincode::serialize(&self.primary_image).unwrap();
@@ -644,6 +653,7 @@ impl Html {
                 | Field::HostCentrality
                 | Field::PageCentrality
                 | Field::FetchTimeMs
+                | Field::PreComputedScore
                 | Field::Region
                 | Field::PrimaryImage => {}
             }


### PR DESCRIPTION
This PR introduces the functionality needed to limit the number of webpages considered for ranking during search.
This PR retrieves and ranks the top 10 million pages. This can be done since we have sorted the postinglists based on
all pre-computable signals. The chance of "the best" webpage being at > 10 mil is extremely low, and this will allow us to speedup search significantly.

When we get more compute we might revert this PR and again consider all webpages during search.