### PR TITLE
Ftr/trust centrality

### DIFF
--- a/docs/trust_centrality_notes.md
+++ b/docs/trust_centrality_notes.md
@@ -1,0 +1,7 @@
+This document is inteded to be a somewhat informal overview of how trust centrality has been derived in order to hopefully give a better understanding of what trust centrality is. It is *not* intended to be of the same quality as a scientific paper and some details may be omitted for simplicity. My algorithm and datastructures teachers would probably slaughter me for the missing details and rambling if I handed this in as an assignment, but here we go
+
+# High-level interpretation of trust centrality values
+
+# Derivation/idea from harmonic centrality combined with distance oracles
+
+# Choice of proxy nodes

--- a/docs/trust_centrality_notes.md
+++ b/docs/trust_centrality_notes.md
@@ -1,7 +1,0 @@
-This document is inteded to be a somewhat informal overview of how trust centrality has been derived in order to hopefully give a better understanding of what trust centrality is. It is *not* intended to be of the same quality as a scientific paper and some details may be omitted for simplicity. My algorithm and datastructures teachers would probably slaughter me for the missing details and rambling if I handed this in as an assignment, but here we go
-
-# High-level interpretation of trust centrality values
-
-# Derivation/idea from harmonic centrality combined with distance oracles
-
-# Choice of proxy nodes

--- a/src/entrypoint/mod.rs
+++ b/src/entrypoint/mod.rs
@@ -60,16 +60,14 @@ async fn async_download_all_warc_files<'a>(
             .unwrap();
         debug!("downloading warc file {}", &warc_path);
         let res = WarcFile::download_into_buf(source, &warc_path, &mut file).await;
+
+        if let Err(err) = res {
+            debug!("error while downloading: {:?}", err);
+        }
+
         debug!("finished downloading");
 
-        (warc_path, res)
+        warc_path
     }))
     .buffer_unordered(num_files)
-    .filter_map(|(path, res)| async move {
-        if res.is_ok() {
-            Some(path.clone())
-        } else {
-            None
-        }
-    })
 }

--- a/src/webgraph/centrality/betweenness.rs
+++ b/src/webgraph/centrality/betweenness.rs
@@ -14,4 +14,143 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// see: https://origin.geeksforgeeks.org/number-shortest-paths-unweighted-directed-graph/
+//! this is an implementation of the algorithm
+//! described in "A Faster Algorithm for Betweenness Centrality"
+
+use std::collections::{HashMap, VecDeque};
+
+use crate::webgraph::{graph_store::GraphStore, Node, NodeID, Store, Webgraph};
+
+fn calculate<S: Store>(store: &GraphStore<S>) -> HashMap<Node, f64> {
+    let mut centrality: HashMap<NodeID, f64> = HashMap::new();
+    let mut n = 0;
+
+    for s in store.nodes() {
+        n += 1;
+        centrality.entry(s).or_default();
+
+        let mut stack = Vec::new();
+        let mut predecessors: HashMap<u64, Vec<u64>> = HashMap::new();
+
+        let mut sigma = HashMap::new();
+        sigma.insert(s, 1);
+
+        let mut distances = HashMap::new();
+        distances.insert(s, 0);
+
+        let mut q = VecDeque::new();
+        q.push_back(s);
+
+        while let Some(v) = q.pop_front() {
+            stack.push(v);
+            for edge in store.outgoing_edges(v) {
+                let w = edge.to;
+                let dist_v = *distances.get(&v).unwrap();
+                distances.entry(w).or_insert_with(|| {
+                    q.push_back(w);
+                    dist_v + 1
+                });
+
+                if *distances.get(&w).unwrap() == *distances.get(&v).unwrap() + 1 {
+                    let sigma_v = *sigma.get(&v).unwrap_or(&0);
+                    *sigma.entry(w).or_insert(0) += sigma_v;
+                    predecessors.entry(w).or_default().push(v);
+                }
+            }
+        }
+
+        let mut delta = HashMap::new();
+        while let Some(w) = stack.pop() {
+            if let Some(pred) = predecessors.get(&w) {
+                for v in pred {
+                    *delta.entry(v).or_default() += (*sigma.get(v).unwrap() as f64
+                        / *sigma.get(&w).unwrap() as f64)
+                        * (1.0 + delta.get(&w).unwrap_or(&0.0));
+                }
+            }
+
+            if w != s {
+                *centrality.entry(w).or_insert(0.0) += *delta.get(&w).unwrap_or(&0.0);
+            }
+        }
+    }
+
+    let n = n as f64;
+    let norm = n * (n - 1.0);
+
+    centrality
+        .into_iter()
+        .map(|(id, centrality)| (store.id2node(&id).unwrap(), centrality / norm))
+        .collect()
+}
+
+#[derive(Debug)]
+pub struct Betweenness {
+    pub full: HashMap<Node, f64>,
+    pub host: HashMap<Node, f64>,
+}
+
+impl Betweenness {
+    pub fn calculate(graph: &Webgraph) -> Self {
+        Self {
+            full: graph.full.as_ref().map(calculate).unwrap_or_default(),
+            host: graph.host.as_ref().map(calculate).unwrap_or_default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maplit::hashmap;
+
+    use crate::webgraph::WebgraphBuilder;
+
+    use super::*;
+
+    fn create_path_graph(n: usize) -> Webgraph {
+        //     ┌────┐
+        //     │    │
+        // ┌───A◄─┐ │
+        // │      │ │
+        // ▼      │ │
+        // B─────►C◄┘
+        //        ▲
+        //        │
+        //        │
+        //        D
+
+        let mut graph = WebgraphBuilder::new_memory()
+            .with_full_graph()
+            .with_host_graph()
+            .open();
+
+        for i in 0..n - 1 {
+            graph.insert(
+                Node::from(i.to_string()),
+                Node::from((i + 1).to_string()),
+                String::new(),
+            );
+        }
+
+        graph.flush();
+
+        graph
+    }
+
+    #[test]
+    fn path() {
+        let p = create_path_graph(5);
+        let centrality = Betweenness::calculate(&p);
+
+        assert_eq!(
+            centrality.host,
+            hashmap! {
+                Node::from("0".to_string()) => 0.0,
+                Node::from("1".to_string()) => 0.15,
+                Node::from("2".to_string()) => 0.2,
+                Node::from("3".to_string()) => 0.15,
+                Node::from("4".to_string()) => 0.0,
+            }
+        );
+    }
+}

--- a/src/webgraph/centrality/betweenness.rs
+++ b/src/webgraph/centrality/betweenness.rs
@@ -1,0 +1,17 @@
+// Cuely is an open source web search engine.
+// Copyright (C) 2022 Cuely ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// see: https://origin.geeksforgeeks.org/number-shortest-paths-unweighted-directed-graph/

--- a/src/webgraph/centrality/harmonic.rs
+++ b/src/webgraph/centrality/harmonic.rs
@@ -1,0 +1,198 @@
+// Cuely is an open source web search engine.
+// Copyright (C) 2022 Cuely ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
+use tracing::info;
+
+use crate::webgraph::{graph_store::GraphStore, Node, NodeID, Store, Webgraph};
+
+pub struct HarmonicCentrality {
+    pub full: HashMap<Node, f64>,
+    pub host: HashMap<Node, f64>,
+}
+
+fn calculate_centrality<S, F>(graph: &GraphStore<S>, node_distances: F) -> HashMap<Node, f64>
+where
+    S: Store,
+    F: Fn(Node) -> HashMap<NodeID, usize>,
+{
+    let nodes: Vec<_> = graph.nodes().collect();
+    info!("Found {} nodes in the graph", nodes.len());
+    let pb = ProgressBar::new(nodes.len() as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{spinner:.green} [{elapsed_precise}] [{wide_bar}] {pos:>7}/{len:7} ({eta})")
+            .progress_chars("#>-"),
+    );
+    let norm_factor = (nodes.len() - 1) as f64;
+    nodes
+        .iter()
+        .progress_with(pb)
+        .map(|node_id| {
+            let node = graph.id2node(node_id).expect("unknown node");
+            let centrality_values: HashMap<NodeID, f64> = node_distances(node.clone())
+                .into_iter()
+                .filter(|(other_id, _)| *other_id != *node_id)
+                .map(|(other_node, dist)| (other_node, 1f64 / dist as f64))
+                .collect();
+
+            let centrality = centrality_values
+                .into_iter()
+                .map(|(_, val)| val)
+                .sum::<f64>()
+                / norm_factor;
+
+            (node, centrality)
+        })
+        .filter(|(_, centrality)| *centrality > 0.0)
+        .collect()
+}
+
+fn calculate_full(graph: &Webgraph) -> HashMap<Node, f64> {
+    graph
+        .full
+        .as_ref()
+        .map(|full_graph| {
+            calculate_centrality(full_graph, |node| graph.raw_reversed_distances(node))
+        })
+        .unwrap_or_default()
+}
+
+fn calculate_host(graph: &Webgraph) -> HashMap<Node, f64> {
+    graph
+        .host
+        .as_ref()
+        .map(|host_graph| {
+            calculate_centrality(host_graph, |node| graph.raw_host_reversed_distances(node))
+        })
+        .unwrap_or_default()
+}
+
+impl HarmonicCentrality {
+    pub fn calculate(graph: &Webgraph) -> Self {
+        Self {
+            host: calculate_host(graph),
+            full: calculate_full(graph),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::webgraph::WebgraphBuilder;
+
+    fn test_graph() -> Webgraph {
+        //     ┌────┐
+        //     │    │
+        // ┌───A◄─┐ │
+        // │      │ │
+        // ▼      │ │
+        // B─────►C◄┘
+        //        ▲
+        //        │
+        //        │
+        //        D
+
+        let mut graph = WebgraphBuilder::new_memory()
+            .with_full_graph()
+            .with_host_graph()
+            .open();
+
+        graph.insert(Node::from("A"), Node::from("B"), String::new());
+        graph.insert(Node::from("B"), Node::from("C"), String::new());
+        graph.insert(Node::from("A"), Node::from("C"), String::new());
+        graph.insert(Node::from("C"), Node::from("A"), String::new());
+        graph.insert(Node::from("D"), Node::from("C"), String::new());
+
+        graph.flush();
+
+        graph
+    }
+
+    #[test]
+    fn host_harmonic_centrality() {
+        let mut graph = WebgraphBuilder::new_memory()
+            .with_full_graph()
+            .with_host_graph()
+            .open();
+
+        graph.insert(Node::from("A.com/1"), Node::from("A.com/2"), String::new());
+        graph.insert(Node::from("A.com/1"), Node::from("A.com/3"), String::new());
+        graph.insert(Node::from("A.com/1"), Node::from("A.com/4"), String::new());
+        graph.insert(Node::from("A.com/2"), Node::from("A.com/1"), String::new());
+        graph.insert(Node::from("A.com/2"), Node::from("A.com/3"), String::new());
+        graph.insert(Node::from("A.com/2"), Node::from("A.com/4"), String::new());
+        graph.insert(Node::from("A.com/3"), Node::from("A.com/1"), String::new());
+        graph.insert(Node::from("A.com/3"), Node::from("A.com/2"), String::new());
+        graph.insert(Node::from("A.com/3"), Node::from("A.com/4"), String::new());
+        graph.insert(Node::from("A.com/4"), Node::from("A.com/1"), String::new());
+        graph.insert(Node::from("A.com/4"), Node::from("A.com/2"), String::new());
+        graph.insert(Node::from("A.com/4"), Node::from("A.com/3"), String::new());
+        graph.insert(Node::from("C.com"), Node::from("B.com"), String::new());
+        graph.insert(Node::from("D.com"), Node::from("B.com"), String::new());
+
+        graph.flush();
+
+        let centrality = HarmonicCentrality::calculate(&graph);
+        assert!(
+            centrality.full.get(&Node::from("A.com/1")).unwrap()
+                > centrality.full.get(&Node::from("B.com")).unwrap()
+        );
+
+        assert!(
+            centrality.host.get(&Node::from("B.com")).unwrap()
+                > centrality.host.get(&Node::from("A.com")).unwrap_or(&0.0)
+        );
+    }
+
+    #[test]
+    fn harmonic_centrality() {
+        let graph = test_graph();
+
+        let centrality = HarmonicCentrality::calculate(&graph);
+
+        assert_eq!(centrality.full.get(&Node::from("C")).unwrap(), &1.0);
+        assert_eq!(centrality.full.get(&Node::from("D")), None);
+        assert_eq!(
+            (*centrality.full.get(&Node::from("A")).unwrap() * 100.0).round() / 100.0,
+            0.67
+        );
+        assert_eq!(
+            (*centrality.full.get(&Node::from("B")).unwrap() * 100.0).round() / 100.0,
+            0.61
+        );
+    }
+
+    #[test]
+    fn www_subdomain_ignored() {
+        let mut graph = WebgraphBuilder::new_memory()
+            .with_full_graph()
+            .with_host_graph()
+            .open();
+
+        graph.insert(Node::from("B.com"), Node::from("A.com"), String::new());
+        graph.insert(Node::from("B.com"), Node::from("www.A.com"), String::new());
+
+        graph.flush();
+        let centrality = HarmonicCentrality::calculate(&graph);
+
+        assert_eq!(centrality.host.get(&Node::from("A.com")), Some(&1.0));
+        assert_eq!(centrality.host.get(&Node::from("www.A.com")), None);
+    }
+}

--- a/src/webgraph/centrality/mod.rs
+++ b/src/webgraph/centrality/mod.rs
@@ -1,0 +1,19 @@
+// Cuely is an open source web search engine.
+// Copyright (C) 2022 Cuely ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pub mod betweenness;
+pub mod harmonic;
+pub mod trust;

--- a/src/webgraph/centrality/trust.rs
+++ b/src/webgraph/centrality/trust.rs
@@ -13,3 +13,11 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Algorithm in broad strokes
+//! We first calculate the betweenness centrality for all nodes an choose top k as proxy nodes.
+//! The distances from every node to every proxy node and reverse is then calculated and stored.
+//!
+//! During search the user can choose a set of trusted node. Every proxy node then gets a weight
+//! of weight(p) = sum(1 / dist(p, t) for t in trusted_nodes). The top s proxy nodes are then chosen to be used during search.
+//! For each search candidate, u, they get a score of score(u) = 1 / (1 + sum(weight(p) * d(p, u) for p in best_proxy_nodes))

--- a/src/webgraph/centrality/trust.rs
+++ b/src/webgraph/centrality/trust.rs
@@ -19,5 +19,153 @@
 //! The distances from every node to every proxy node and reverse is then calculated and stored.
 //!
 //! During search the user can choose a set of trusted node. Every proxy node then gets a weight
-//! of weight(p) = sum(1 / dist(p, t) for t in trusted_nodes). The top s proxy nodes are then chosen to be used during search.
+//! of weight(p) = 1 / sum(dist(p, t) for t in trusted_nodes). The top s proxy nodes are then chosen to be used during search.
 //! For each search candidate, u, they get a score of score(u) = 1 / (1 + sum(weight(p) * d(p, u) for p in best_proxy_nodes))
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
+use crate::webgraph::{centrality::betweenness::Betweenness, NodeID, Webgraph};
+use crate::Result;
+
+const NUM_PROXY_NODES: usize = 1_000;
+const NUM_PROXY_NODES_FOR_SEARCH: usize = 10;
+
+#[derive(Serialize, Deserialize)]
+struct ProxyNode {
+    id: NodeID,
+    dist_from_node: HashMap<NodeID, usize>, // from node to proxy node
+    dist_to_node: HashMap<NodeID, usize>,   // from proxy node to other node
+}
+
+struct WeightedProxyNode<'a> {
+    weight: f64,
+    node: &'a ProxyNode,
+    max_dist: usize,
+}
+
+impl<'a> WeightedProxyNode<'a> {
+    fn new(proxy: &'a ProxyNode, trusted_nodes: &[NodeID], max_dist: usize) -> Self {
+        let weight = 1.0
+            / trusted_nodes
+                .iter()
+                .map(|node| *proxy.dist_from_node.get(node).unwrap_or(&max_dist) as f64)
+                .sum::<f64>();
+
+        Self {
+            node: proxy,
+            weight,
+            max_dist,
+        }
+    }
+
+    fn score(&self, node: NodeID) -> f64 {
+        self.weight
+            * *self
+                .node
+                .dist_to_node
+                .get(&node)
+                .unwrap_or(&(self.max_dist + 1)) as f64
+    }
+}
+
+pub struct Scorer<'a> {
+    proxy_nodes: Vec<WeightedProxyNode<'a>>,
+}
+
+impl<'a> Scorer<'a> {
+    fn new(proxy_nodes: &'a [ProxyNode], trusted_nodes: &[NodeID], max_dist: usize) -> Self {
+        let mut proxy_nodes: Vec<_> = proxy_nodes
+            .into_iter()
+            .map(|node| WeightedProxyNode::new(node, trusted_nodes, max_dist))
+            .collect();
+
+        proxy_nodes.sort_by(|a, b| {
+            b.weight
+                .partial_cmp(&a.weight)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        Self {
+            proxy_nodes: proxy_nodes
+                .into_iter()
+                .take(NUM_PROXY_NODES_FOR_SEARCH)
+                .collect(),
+        }
+    }
+
+    pub fn score(&self, node: NodeID) -> f64 {
+        1.0 / (1.0
+            + self
+                .proxy_nodes
+                .iter()
+                .map(|proxy| proxy.score(node))
+                .sum::<f64>())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TrustedCentrality {
+    proxy_nodes: Vec<ProxyNode>,
+    max_dist: usize,
+}
+
+impl TrustedCentrality {
+    pub fn new(graph: &Webgraph) -> Self {
+        let betweenness = Betweenness::calculate(graph);
+        let mut nodes = betweenness.centrality.into_iter().collect_vec();
+        nodes.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        let proxy_nodes = nodes
+            .into_iter()
+            .map(|(node, _)| node)
+            .map(|node| (graph.host.as_ref().unwrap().node2id(&node).unwrap(), node))
+            .map(|(id, node)| ProxyNode {
+                id,
+                dist_to_node: graph
+                    .host_distances(node.clone())
+                    .into_iter()
+                    .map(|(node, dist)| {
+                        (graph.host.as_ref().unwrap().node2id(&node).unwrap(), dist)
+                    })
+                    .collect(),
+                dist_from_node: graph
+                    .host_reversed_distances(node.clone())
+                    .into_iter()
+                    .map(|(node, dist)| {
+                        (graph.host.as_ref().unwrap().node2id(&node).unwrap(), dist)
+                    })
+                    .collect(),
+            })
+            .take(NUM_PROXY_NODES)
+            .collect_vec();
+
+        Self {
+            proxy_nodes,
+            max_dist: betweenness.max_dist,
+        }
+    }
+
+    pub fn scorer(&self, trusted_nodes: &[NodeID]) -> Scorer<'_> {
+        Scorer::new(&self.proxy_nodes, trusted_nodes, self.max_dist)
+    }
+
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        todo!();
+    }
+
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
+        todo!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn trusted_centrality() {
+        todo!("example from ipad");
+    }
+}

--- a/src/webgraph/centrality/trust.rs
+++ b/src/webgraph/centrality/trust.rs
@@ -1,0 +1,15 @@
+// Cuely is an open source web search engine.
+// Copyright (C) 2022 Cuely ApS
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/webgraph/mod.rs
+++ b/src/webgraph/mod.rs
@@ -15,13 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 mod graph_store;
 
-use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
 use serde::{Deserialize, Serialize};
 use std::collections::{BinaryHeap, HashMap};
 use std::path::Path;
 use std::sync::Mutex;
 use std::{cmp, fs};
-use tracing::info;
 
 use graph_store::GraphStore;
 
@@ -30,6 +28,8 @@ use crate::webpage::Url;
 
 use self::graph_store::Adjacency;
 use crate::kv::rocksdb_store::RocksDbStore;
+
+pub mod centrality;
 
 type NodeID = u64;
 
@@ -211,14 +211,14 @@ impl WebgraphBuilder {
     pub fn open(self) -> Webgraph {
         if self.read_only {
             Webgraph {
-                full_graph: self.full_graph_path.map(GraphStore::open_read_only),
-                host_graph: self.host_graph_path.map(GraphStore::open_read_only),
+                full: self.full_graph_path.map(GraphStore::open_read_only),
+                host: self.host_graph_path.map(GraphStore::open_read_only),
                 path: self.path.to_str().unwrap().to_string(),
             }
         } else {
             Webgraph {
-                full_graph: self.full_graph_path.map(GraphStore::open),
-                host_graph: self.host_graph_path.map(GraphStore::open),
+                full: self.full_graph_path.map(GraphStore::open),
+                host: self.host_graph_path.map(GraphStore::open),
                 path: self.path.to_str().unwrap().to_string(),
             }
         }
@@ -239,31 +239,31 @@ where
 
 pub struct Webgraph<S: Store = RocksDbStore> {
     pub path: String,
-    full_graph: Option<GraphStore<S>>,
-    host_graph: Option<GraphStore<S>>,
+    pub full: Option<GraphStore<S>>,
+    pub host: Option<GraphStore<S>>,
 }
 
 impl<S: Store> Webgraph<S> {
     pub fn insert(&mut self, from: Node, to: Node, label: String) {
-        if let Some(full_graph) = &mut self.full_graph {
+        if let Some(full_graph) = &mut self.full {
             full_graph.insert(from.clone(), to.clone(), label.clone());
         }
 
-        if let Some(host_graph) = &mut self.host_graph {
+        if let Some(host_graph) = &mut self.host {
             host_graph.insert(from.into_host(), to.into_host(), label);
         }
     }
 
     pub fn merge(&mut self, other: Webgraph<S>) {
-        match (&mut self.full_graph, other.full_graph) {
+        match (&mut self.full, other.full) {
             (Some(self_graph), Some(other_graph)) => self_graph.append(other_graph),
-            (None, Some(other_graph)) => self.full_graph = Some(other_graph),
+            (None, Some(other_graph)) => self.full = Some(other_graph),
             (Some(_), None) | (None, None) => {}
         }
 
-        match (&mut self.host_graph, other.host_graph) {
+        match (&mut self.host, other.host) {
             (Some(self_graph), Some(other_graph)) => self_graph.append(other_graph),
-            (None, Some(other_graph)) => self.host_graph = Some(other_graph),
+            (None, Some(other_graph)) => self.host = Some(other_graph),
             (Some(_), None) | (None, None) => {}
         }
 
@@ -315,7 +315,7 @@ impl<S: Store> Webgraph<S> {
 
     #[allow(unused)]
     pub fn distances(&self, source: Node) -> HashMap<Node, usize> {
-        self.full_graph
+        self.full
             .as_ref()
             .map(|full_graph| {
                 let distances = Webgraph::dijkstra(
@@ -335,7 +335,7 @@ impl<S: Store> Webgraph<S> {
 
     #[allow(unused)]
     fn raw_reversed_distances(&self, source: Node) -> HashMap<NodeID, usize> {
-        self.full_graph
+        self.full
             .as_ref()
             .map(|full_graph| {
                 Webgraph::dijkstra(
@@ -350,7 +350,7 @@ impl<S: Store> Webgraph<S> {
 
     #[allow(unused)]
     pub fn reversed_distances(&self, source: Node) -> HashMap<Node, usize> {
-        self.full_graph
+        self.full
             .as_ref()
             .map(|full_graph| {
                 self.raw_reversed_distances(source)
@@ -363,7 +363,7 @@ impl<S: Store> Webgraph<S> {
 
     #[allow(unused)]
     pub fn host_distances(&self, source: Node) -> HashMap<Node, usize> {
-        self.host_graph
+        self.host
             .as_ref()
             .map(|host_graph| {
                 let distances = Webgraph::dijkstra(
@@ -382,7 +382,7 @@ impl<S: Store> Webgraph<S> {
     }
 
     fn raw_host_reversed_distances(&self, source: Node) -> HashMap<NodeID, usize> {
-        self.host_graph
+        self.host
             .as_ref()
             .map(|host_graph| {
                 Webgraph::dijkstra(
@@ -397,7 +397,7 @@ impl<S: Store> Webgraph<S> {
 
     #[allow(unused)]
     pub fn host_reversed_distances(&self, source: Node) -> HashMap<Node, usize> {
-        self.host_graph
+        self.host
             .as_ref()
             .map(|host_graph| {
                 self.raw_host_reversed_distances(source)
@@ -408,76 +408,17 @@ impl<S: Store> Webgraph<S> {
             .unwrap_or_default()
     }
 
-    fn calculate_centrality<F>(graph: &GraphStore<S>, node_distances: F) -> HashMap<Node, f64>
-    where
-        F: Fn(Node) -> HashMap<NodeID, usize>,
-    {
-        let nodes: Vec<_> = graph.nodes().collect();
-        info!("Found {} nodes in the graph", nodes.len());
-        let pb = ProgressBar::new(nodes.len() as u64);
-        pb.set_style(
-            ProgressStyle::default_bar()
-                .template(
-                    "{spinner:.green} [{elapsed_precise}] [{wide_bar}] {pos:>7}/{len:7} ({eta})",
-                )
-                .progress_chars("#>-"),
-        );
-        let norm_factor = (nodes.len() - 1) as f64;
-        nodes
-            .iter()
-            .progress_with(pb)
-            .map(|node_id| {
-                let node = graph.id2node(node_id).expect("unknown node");
-                let centrality_values: HashMap<NodeID, f64> = node_distances(node.clone())
-                    .into_iter()
-                    .filter(|(other_id, _)| *other_id != *node_id)
-                    .map(|(other_node, dist)| (other_node, 1f64 / dist as f64))
-                    .collect();
-
-                let centrality = centrality_values
-                    .into_iter()
-                    .map(|(_, val)| val)
-                    .sum::<f64>()
-                    / norm_factor;
-
-                (node, centrality)
-            })
-            .filter(|(_, centrality)| *centrality > 0.0)
-            .collect()
-    }
-
-    #[allow(unused)]
-    pub fn harmonic_centrality(&self) -> HashMap<Node, f64> {
-        self.full_graph
-            .as_ref()
-            .map(|full_graph| {
-                Webgraph::calculate_centrality(full_graph, |node| self.raw_reversed_distances(node))
-            })
-            .unwrap_or_default()
-    }
-
-    pub fn host_harmonic_centrality(&self) -> HashMap<Node, f64> {
-        self.host_graph
-            .as_ref()
-            .map(|host_graph| {
-                Webgraph::calculate_centrality(host_graph, |node| {
-                    self.raw_host_reversed_distances(node)
-                })
-            })
-            .unwrap_or_default()
-    }
-
     pub fn flush(&self) {
-        if let Some(full_graph) = &self.full_graph {
+        if let Some(full_graph) = &self.full {
             full_graph.flush();
         }
-        if let Some(host_graph) = &self.host_graph {
+        if let Some(host_graph) = &self.host {
             host_graph.flush();
         }
     }
 
     pub fn ingoing_edges(&self, node: Node) -> Vec<FullEdge> {
-        if let Some(graph) = &self.full_graph {
+        if let Some(graph) = &self.full {
             if let Some(node_id) = graph.node2id(&node) {
                 graph
                     .ingoing_edges(node_id)
@@ -533,8 +474,8 @@ impl From<Webgraph> for FrozenWebgraph {
     fn from(graph: Webgraph) -> Self {
         graph.flush();
         let path = graph.path.clone();
-        let has_full = graph.full_graph.is_some();
-        let has_host = graph.host_graph.is_some();
+        let has_full = graph.full.is_some();
+        let has_host = graph.host.is_some();
         drop(graph);
         let root = directory::scan_folder(path).unwrap();
 
@@ -618,78 +559,6 @@ mod test {
         assert_eq!(distances.get(&Node::from("C")), Some(&1));
         assert_eq!(distances.get(&Node::from("D")), Some(&2));
         assert_eq!(distances.get(&Node::from("B")), Some(&2));
-    }
-
-    #[test]
-    fn harmonic_centrality() {
-        let graph = test_graph();
-
-        let centrality = graph.harmonic_centrality();
-
-        assert_eq!(centrality.get(&Node::from("C")).unwrap(), &1.0);
-        assert_eq!(centrality.get(&Node::from("D")), None);
-        assert_eq!(
-            (*centrality.get(&Node::from("A")).unwrap() * 100.0).round() / 100.0,
-            0.67
-        );
-        assert_eq!(
-            (*centrality.get(&Node::from("B")).unwrap() * 100.0).round() / 100.0,
-            0.61
-        );
-    }
-
-    #[test]
-    fn host_harmonic_centrality() {
-        let mut graph = WebgraphBuilder::new_memory()
-            .with_full_graph()
-            .with_host_graph()
-            .open();
-
-        graph.insert(Node::from("A.com/1"), Node::from("A.com/2"), String::new());
-        graph.insert(Node::from("A.com/1"), Node::from("A.com/3"), String::new());
-        graph.insert(Node::from("A.com/1"), Node::from("A.com/4"), String::new());
-        graph.insert(Node::from("A.com/2"), Node::from("A.com/1"), String::new());
-        graph.insert(Node::from("A.com/2"), Node::from("A.com/3"), String::new());
-        graph.insert(Node::from("A.com/2"), Node::from("A.com/4"), String::new());
-        graph.insert(Node::from("A.com/3"), Node::from("A.com/1"), String::new());
-        graph.insert(Node::from("A.com/3"), Node::from("A.com/2"), String::new());
-        graph.insert(Node::from("A.com/3"), Node::from("A.com/4"), String::new());
-        graph.insert(Node::from("A.com/4"), Node::from("A.com/1"), String::new());
-        graph.insert(Node::from("A.com/4"), Node::from("A.com/2"), String::new());
-        graph.insert(Node::from("A.com/4"), Node::from("A.com/3"), String::new());
-        graph.insert(Node::from("C.com"), Node::from("B.com"), String::new());
-        graph.insert(Node::from("D.com"), Node::from("B.com"), String::new());
-
-        graph.flush();
-
-        let centrality = graph.harmonic_centrality();
-        assert!(
-            centrality.get(&Node::from("A.com/1")).unwrap()
-                > centrality.get(&Node::from("B.com")).unwrap()
-        );
-
-        let host_centrality = graph.host_harmonic_centrality();
-        assert!(
-            host_centrality.get(&Node::from("B.com")).unwrap()
-                > host_centrality.get(&Node::from("A.com")).unwrap_or(&0.0)
-        );
-    }
-
-    #[test]
-    fn www_subdomain_ignored() {
-        let mut graph = WebgraphBuilder::new_memory()
-            .with_full_graph()
-            .with_host_graph()
-            .open();
-
-        graph.insert(Node::from("B.com"), Node::from("A.com"), String::new());
-        graph.insert(Node::from("B.com"), Node::from("www.A.com"), String::new());
-
-        graph.flush();
-
-        let centrality = graph.host_harmonic_centrality();
-        assert_eq!(centrality.get(&Node::from("A.com")), Some(&1.0));
-        assert_eq!(centrality.get(&Node::from("www.A.com")), None);
     }
 
     #[test]

--- a/src/webgraph/mod.rs
+++ b/src/webgraph/mod.rs
@@ -361,7 +361,6 @@ impl<S: Store> Webgraph<S> {
             .unwrap_or_default()
     }
 
-    #[allow(unused)]
     pub fn host_distances(&self, source: Node) -> HashMap<Node, usize> {
         self.host
             .as_ref()
@@ -395,7 +394,6 @@ impl<S: Store> Webgraph<S> {
             .unwrap_or_default()
     }
 
-    #[allow(unused)]
     pub fn host_reversed_distances(&self, source: Node) -> HashMap<Node, usize> {
         self.host
             .as_ref()


### PR DESCRIPTION
Allow the user to specify a set of websites which they trust. We can then rank the search results such that websites with a short distance from the users trusted websites gets ranked higher.