### PR TITLE
Frontend: Update dependencies and run Prettier

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,23 @@
+# build output
+dist/
+.output/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+# public
+public/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,23 +7,24 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "prettier": "prettier -w . --cache"
   },
   "dependencies": {
-    "@alpinejs/persist": "^3.10.4",
-    "@types/alpinejs": "^3.7.0",
-    "alpinejs": "^3.10.4",
-    "astro": "^1.1.6",
-    "astro-icon": "^0.7.3"
+    "@alpinejs/persist": "^3.10.5",
+    "@types/alpinejs": "^3.7.1",
+    "alpinejs": "^3.10.5",
+    "astro": "^1.7.2",
+    "astro-icon": "^0.8.0"
   },
   "devDependencies": {
-    "@astrojs/mdx": "^0.11.1",
-    "@astrojs/tailwind": "^1.0.0",
-    "@faker-js/faker": "^7.5.0",
-    "@fontsource/montserrat": "^4.5.12",
-    "@tailwindcss/typography": "^0.5.7",
-    "prettier": "^2.7.1",
-    "prettier-plugin-astro": "^0.5.5",
-    "prettier-plugin-tailwindcss": "^0.1.13"
+    "@astrojs/mdx": "^0.13.0",
+    "@astrojs/tailwind": "^2.1.3",
+    "@faker-js/faker": "^7.6.0",
+    "@fontsource/montserrat": "^4.5.13",
+    "@tailwindcss/typography": "^0.5.8",
+    "prettier": "^2.8.1",
+    "prettier-plugin-astro": "^0.7.0",
+    "prettier-plugin-tailwindcss": "^0.2.1"
   }
 }

--- a/frontend/src/components/Entity.astro
+++ b/frontend/src/components/Entity.astro
@@ -7,7 +7,7 @@ export interface Props {
 ---
 
 <div class="flex justify-center">
-  <div class="max-w-md flex flex-col items-center">
+  <div class="flex max-w-md flex-col items-center">
     {
       askama.if_("let Some(image) = entity.image_base64", () => (
         <div class="w-lg mb-5">
@@ -23,7 +23,7 @@ export interface Props {
         </div>
       ))
     }
-    <div class="text-xl mb-5">
+    <div class="mb-5 text-xl">
       <a href="https://en.wikipedia.org/wiki/{{ entity.title }}"
         >{askama`entity.title $ {{name.fullName}}`}
       </a>

--- a/frontend/src/components/Footer.astro
+++ b/frontend/src/components/Footer.astro
@@ -1,3 +1,3 @@
-<div class="flex w-full justify-center items-center py-10">
+<div class="flex w-full items-center justify-center py-10">
   <a href="/privacy-and-happy-lawyers">Terms & Privacy</a>
 </div>

--- a/frontend/src/components/Header.astro
+++ b/frontend/src/components/Header.astro
@@ -11,7 +11,7 @@ const { icon = true, searchbar } = Astro.props;
 ---
 
 <div
-  class="grid items-center h-24 grid-cols-[auto_1fr_auto] sm:grid-cols-[3rem_1fr_auto] sm:gap-4 md:gap-5 p-4 lg:gap-10 lg:pr-8 lg:pl-14"
+  class="grid h-24 grid-cols-[auto_1fr_auto] items-center p-4 sm:grid-cols-[3rem_1fr_auto] sm:gap-4 md:gap-5 lg:gap-10 lg:pr-8 lg:pl-14"
 >
   {
     icon && (

--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -20,7 +20,7 @@ const icons = [
 ];
 ---
 
-<navbar class="hidden sm:flex items-center space-x-2 md:space-x-4 lg:space-x-8">
+<navbar class="hidden items-center space-x-2 sm:flex md:space-x-4 lg:space-x-8">
   {
     links.map((l) => (
       <a class="link rounded-full px-2 py-1" href={l.url}>
@@ -37,17 +37,17 @@ const icons = [
   }
 </navbar>
 
-<nav class="sm:hidden items-center flex group relative text-lg">
+<nav class="group relative flex items-center text-lg sm:hidden">
   <button
-    class="px-3 mx-1 text-gray-400 bg-transparent rounded-full transition aspect-square group-hover:text-brand/30"
+    class="mx-1 aspect-square rounded-full bg-transparent px-3 text-gray-400 transition group-hover:text-brand/30"
   >
     <Hero class="w-6" icon="menu" />
   </button>
   <div
-    class="absolute z-50 opacity-0 bottom-0 pt-1 right-0 translate-y-full pointer-events-none group-hover:pointer-events-auto group-hover:flex group-hover:opacity-100 flex-col transition"
+    class="pointer-events-none absolute bottom-0 right-0 z-50 translate-y-full flex-col pt-1 opacity-0 transition group-hover:pointer-events-auto group-hover:flex group-hover:opacity-100"
   >
-    <div class="p-2 bg-white shadow-xl rounded-xl border">
-      <div class="pb-2 flex flex-col space-y-1">
+    <div class="rounded-xl border bg-white p-2 shadow-xl">
+      <div class="flex flex-col space-y-1 pb-2">
         {
           links.map((l) => (
             <a class="link rounded py-1 pl-2 pr-10" href={l.url}>
@@ -56,7 +56,7 @@ const icons = [
           ))
         }
       </div>
-      <div class="flex border-t pt-2 justify-around">
+      <div class="flex justify-around border-t pt-2">
         {
           icons.map((i) => (
             <a class="icon" href={i.url}>

--- a/frontend/src/components/OpticSelector.astro
+++ b/frontend/src/components/OpticSelector.astro
@@ -7,13 +7,13 @@ export interface Props {
 import { askama } from "$/askama";
 ---
 
-<div class="h-full flex flex-col justify-center p-0 m-0">
+<div class="m-0 flex h-full flex-col justify-center p-0">
   <select
     form="searchbar-form"
     id="optics-selector"
     name="optic"
     onchange="document.getElementById('searchbar-form').submit()"
-    class="p-0 m-0 hover:cursor-pointer bg-transparent text-sm border-0 max-w-[100px]"
+    class="m-0 max-w-[100px] border-0 bg-transparent p-0 text-sm hover:cursor-pointer"
     x-data="{ items: $persist([]).as('optics') }"
   >
     <option value="">Optic</option>
@@ -28,9 +28,7 @@ import { askama } from "$/askama";
                 {askama`optic.name`}
               </option>
             ),
-            () => (
-              <option value="{{ optic.url }}">{askama`optic.name`}</option>
-            )
+            () => <option value="{{ optic.url }}">{askama`optic.name`}</option>
           ),
           None: <option value="{{ optic.url }}">{askama`optic.name`}</option>,
         })

--- a/frontend/src/components/RankingModal.astro
+++ b/frontend/src/components/RankingModal.astro
@@ -1,5 +1,5 @@
 <div
-  class="flex text-sm flex-col py-5 px-2 items-center h-fit w-52 overflow-hidden absolute border rounded-lg drop-shadow-md bg-white origin-left modal-closed"
+  class="modal-closed absolute flex h-fit w-52 origin-left flex-col items-center overflow-hidden rounded-lg border bg-white py-5 px-2 text-sm drop-shadow-md"
   id="ranking-modal"
 >
   <h2 class="w-fit text-center">
@@ -7,23 +7,23 @@
       EXAMPLE.com
     </span>?
   </h2>
-  <div class="flex flex-col w-fit pt-4 space-y-3">
+  <div class="flex w-fit flex-col space-y-3 pt-4">
     <button
-      class="bg-white border rounded-full px-4 py-1 hover:bg-slate-600 hover:text-white"
+      class="rounded-full border bg-white px-4 py-1 hover:bg-slate-600 hover:text-white"
       onclick="preferMore()"
       id="prefer-more"
     >
       Like
     </button>
     <button
-      class="bg-white border rounded-full px-4 py-1 hover:bg-slate-600 hover:text-white"
+      class="rounded-full border bg-white px-4 py-1 hover:bg-slate-600 hover:text-white"
       onclick="preferLess()"
       id="prefer-less"
     >
       Dislike
     </button>
     <button
-      class="bg-white border rounded-full px-4 py-1 hover:bg-slate-600 hover:text-white"
+      class="rounded-full border bg-white px-4 py-1 hover:bg-slate-600 hover:text-white"
       onclick="block()"
       id="prefer-block"
     >

--- a/frontend/src/components/Searchbar.astro
+++ b/frontend/src/components/Searchbar.astro
@@ -27,16 +27,16 @@ const { autofocus, query } = Astro.props;
 </style>
 
 <form
-  class="w-full relative"
+  class="relative w-full"
   id="searchbar-form"
   method="GET"
   action="/search"
   autocomplete="off"
 >
-  <div class="h-12 relative">
+  <div class="relative h-12">
     <div
       id="searchbar"
-      class="absolute group bg-white top-0 grid grid-cols-[auto_1fr_auto] grid-rows-[3rem] border rounded-3xl inset-x-0 focus-within:shadow transition-shadow"
+      class="group absolute inset-x-0 top-0 grid grid-cols-[auto_1fr_auto] grid-rows-[3rem] rounded-3xl border bg-white transition-shadow focus-within:shadow"
     >
       <Hero
         class="col-[1/2] row-start-1 w-5 self-center ml-5 text-gray-400"
@@ -47,13 +47,13 @@ const { autofocus, query } = Astro.props;
         value={query}
         autofocus={autofocus}
         name="q"
-        class="searchbar-input peer h-full flex inset-y-0 col-[1/3] py-0 row-start-1 w-full grow focus:ring-0 pl-12 border-none outline-none bg-transparent"
+        class="searchbar-input peer inset-y-0 col-[1/3] row-start-1 flex h-full w-full grow border-none bg-transparent py-0 pl-12 outline-none focus:ring-0"
         placeholder="Search"
       />
-      <div class="flex w-12 justify-center items-center">
+      <div class="flex w-12 items-center justify-center">
         <button
           type="submit"
-          class="bg-transparent p-0 m-0"
+          class="m-0 bg-transparent p-0"
           style="border: none"
           title="Search"
         >

--- a/frontend/src/components/SettingsMenu.astro
+++ b/frontend/src/components/SettingsMenu.astro
@@ -5,7 +5,7 @@ const links = [
 ];
 ---
 
-<div class="relative flex flex-col right-20 space-y-3">
+<div class="relative right-20 flex flex-col space-y-3">
   {
     links.map((l) => (
       <a class="link rounded-full px-2 py-1 text-center" href={l.url}>

--- a/frontend/src/components/Sidebar.astro
+++ b/frontend/src/components/Sidebar.astro
@@ -4,18 +4,17 @@ import Entity from "../components/Entity.astro";
 import StackOverflow from "../components/StackOverflow.astro";
 
 export interface Props {
-    sidebar: string;
+  sidebar: string;
 }
 ---
+
 <div>
-{
+  {
     askama.match("sidebar", {
-        "DisplayedSidebar::Entity(entity)": (
-            <Entity entity = "entity" />
-        ),
-        "DisplayedSidebar::StackOverflow{title, answer}": (
-            <StackOverflow title = "title" answer = "answer" />
-        )
+      "DisplayedSidebar::Entity(entity)": <Entity entity="entity" />,
+      "DisplayedSidebar::StackOverflow{title, answer}": (
+        <StackOverflow title="title" answer="answer" />
+      ),
     })
-}
+  }
 </div>

--- a/frontend/src/components/Snippet.astro
+++ b/frontend/src/components/Snippet.astro
@@ -6,93 +6,78 @@ export interface Props {
   snippet: string;
 }
 ---
+
 <div>
-    {
+  {
     askama.match("item.snippet", {
-        "Snippet::Normal { date, text }": (
-            <div>
-                {askama.if_("let Some(date) = date", () => (
-                <span class="text-gray-500">
-                    {askama`date $ 2. May 2022`}
-                </span>
-                ))}
-                <span class="[&:nth-child(2)]:before:content-['—']">
-                {askama`text|safe $ {{lorem.lines}}`}
-                </span>
+      "Snippet::Normal { date, text }": (
+        <div>
+          {askama.if_("let Some(date) = date", () => (
+            <span class="text-gray-500">{askama`date $ 2. May 2022`}</span>
+          ))}
+          <span class="[&:nth-child(2)]:before:content-['—']">
+            {askama`text|safe $ {{lorem.lines}}`}
+          </span>
+        </div>
+      ),
+      "Snippet::StackOverflowQA { question, answers }": (
+        <div>
+          <div>
+            <div class="max-h-16 overflow-hidden break-words">
+              {askama.for_("part in question.body", () =>
+                askama.match("part", {
+                  "CodeOrText::Text(text)": <span>{askama`text`}</span>,
+                  "CodeOrText::Code(code)": <span>{askama`code`}</span>,
+                })
+              )}
             </div>
-        ),
-        "Snippet::StackOverflowQA { question, answers }": (
-            <div>
-                <div>
-                    <div class="max-h-16 overflow-hidden break-words">
-                    {
-                    askama.for_("part in question.body", () => (
-                        <>
-                        {
-                        askama.match("part", {
-                            "CodeOrText::Text(text)": (
-                                <span>{askama`text`}</span>
-                            ),
-                            "CodeOrText::Code(code)": (
-                                <span>{askama `code`}</span>
-                            )
-                        })
-                        }
-                        </>
-                    ))
-                    }
-                    </div>
-                </div>
-                <div class="text-sm flex space-x-2">
-                {
-                askama.for_("answer in answers", () => (
-                    <a class="bg-slate-100 hover:bg-slate-600 hover:text-white h-52 w-1/3 p-5 rounded-lg hover:cursor-pointer hover:no-underline" href="{{ answer.url }}">
-                        <div class="w-full h-full overflow-hidden">
-                            <div class="flex justify-between grow mb-2">
-                                <div>{askama`answer.date`}</div>
-                                <div class="flex space-x-2">
-                                    <div class="flex items-center space-x-1">
-                                        <span class="h-fit">
-                                            {askama`answer.upvotes`}
-                                        </span>
-                                        <div class="h-fit">
-                                            <Hero class="w-3" icon="thumb-up" />
-                                        </div>
-                                    </div>
-                                    {
-                                        askama.if_("answer.accepted", () => (
-                                            <div>
-                                                <Hero class="w-5 text-green-500" icon="check" />
-                                            </div>
-                                        ))
-                                    }
-                                    </div>
-                                </div>
-                            <div>
-                                {
-                                askama.for_("part in answer.body", () => (
-                                    <div class="select-none">
-                                    {
-                                        askama.match("part", {
-                                            "CodeOrText::Text(text)": (
-                                                <span>{askama`text`}</span>
-                                            ),
-                                            "CodeOrText::Code(code)": (
-                                                <pre class="select-none"><code class="rounded-lg select-none" style="background: none">{askama `code`}</code></pre>
-                                            )
-                                        })
-                                    }
-                                    </div>
-                                ))
-                                }
-                            </div>
+          </div>
+          <div class="flex space-x-2 text-sm">
+            {askama.for_("answer in answers", () => (
+              <a
+                class="h-52 w-1/3 rounded-lg bg-slate-100 p-5 hover:cursor-pointer hover:bg-slate-600 hover:text-white hover:no-underline"
+                href="{{ answer.url }}"
+              >
+                <div class="h-full w-full overflow-hidden">
+                  <div class="mb-2 flex grow justify-between">
+                    <div>{askama`answer.date`}</div>
+                    <div class="flex space-x-2">
+                      <div class="flex items-center space-x-1">
+                        <span class="h-fit">{askama`answer.upvotes`}</span>
+                        <div class="h-fit">
+                          <Hero class="w-3" icon="thumb-up" />
                         </div>
-                    </a>
-                ))
-                }
+                      </div>
+                      {askama.if_("answer.accepted", () => (
+                        <div>
+                          <Hero class="w-5 text-green-500" icon="check" />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    {askama.for_("part in answer.body", () => (
+                      <div class="select-none">
+                        {askama.match("part", {
+                          "CodeOrText::Text(text)": <span>{askama`text`}</span>,
+                          "CodeOrText::Code(code)": (
+                            <pre class="select-none">
+                              <code
+                                class="select-none rounded-lg"
+                                style="background: none"
+                              >{askama`code`}</code>
+                            </pre>
+                          ),
+                        })}
+                      </div>
+                    ))}
+                  </div>
                 </div>
-            </div>
-        )
+              </a>
+            ))}
+          </div>
+        </div>
+      ),
     })
-    }
+  }
 </div>

--- a/frontend/src/components/StackOverflow.astro
+++ b/frontend/src/components/StackOverflow.astro
@@ -7,22 +7,25 @@ export interface Props {
   answer: string;
 }
 ---
-<div class="flex flex-col space-y-5 border p-5 rounded-lg max-w-lg">
+
+<div class="flex max-w-lg flex-col space-y-5 rounded-lg border p-5">
   <div class="flex flex-col space-y-1">
-    <div class="flex justify-between space-x-2 grow">
+    <div class="flex grow justify-between space-x-2">
       <div>
-        <a class="text-lg font-medium" href={askama`answer.url`}>{askama`title`}</a>
+        <a class="text-lg font-medium" href={askama`answer.url`}
+          >{askama`title`}</a
+        >
       </div>
-      <div class="flex space-x-1 items-center">
-          <span class="h-fit">
-            {askama`answer.upvotes`}
-          </span>
-          <div class="h-fit">
-            <Hero class="w-4" icon="thumb-up" />
-          </div>
+      <div class="flex items-center space-x-1">
+        <span class="h-fit">
+          {askama`answer.upvotes`}
+        </span>
+        <div class="h-fit">
+          <Hero class="w-4" icon="thumb-up" />
+        </div>
       </div>
     </div>
-    <div class="flex justify-between space-x-2 grow">
+    <div class="flex grow justify-between space-x-2">
       <div><a href={askama`answer.url`}>{askama`answer.url`}</a></div>
       <div>{askama`answer.date`}</div>
     </div>
@@ -30,20 +33,18 @@ export interface Props {
   <hr />
   <div class="flex flex-col space-y-3">
     {
-    askama.for_("part in answer.body", () => (
+      askama.for_("part in answer.body", () => (
         <div>
-        {
-            askama.match("part", {
-                "CodeOrText::Text(text)": (
-                    <span>{askama`text`}</span>
-                ),
-                "CodeOrText::Code(code)": (
-                    <pre class="bg-slate-50 rounded-lg"><code style="background: none">{askama `code`}</code></pre>
-                )
-            })
-        }
+          {askama.match("part", {
+            "CodeOrText::Text(text)": <span>{askama`text`}</span>,
+            "CodeOrText::Code(code)": (
+              <pre class="rounded-lg bg-slate-50">
+                <code style="background: none">{askama`code`}</code>
+              </pre>
+            ),
+          })}
         </div>
-    ))
+      ))
     }
   </div>
 </div>

--- a/frontend/src/layouts/Markdown.astro
+++ b/frontend/src/layouts/Markdown.astro
@@ -11,12 +11,12 @@ const { frontmatter } = Astro.props;
 ---
 
 <Layout title={frontmatter.title}>
-  <div class="flex flex-col h-full w-full">
+  <div class="flex h-full w-full flex-col">
     <Header />
 
-    <div class="flex flex-col w-full h-fit items-center pt-10">
+    <div class="flex h-fit w-full flex-col items-center pt-10">
       <div
-        class="prose prose-sm prose-headings:text-center prose-headings:font-medium prose-h4:float-left prose-h4:mr-3 prose-h4:my-0 prose-h4:leading-7"
+        class="prose prose-sm prose-headings:text-center prose-headings:font-medium prose-h4:float-left prose-h4:my-0 prose-h4:mr-3 prose-h4:leading-7"
       >
         <slot />
       </div>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -6,14 +6,14 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Cuely">
-  <div class="grid grid-rows-[auto_1fr_auto] h-full relative">
+  <div class="relative grid h-full grid-rows-[auto_1fr_auto]">
     <Header icon={false} />
-    <div class="absolute top-1/4 w-full grid place-items-center">
+    <div class="absolute top-1/4 grid w-full place-items-center">
       <div
-        class="flex flex-col justify-center items-center w-full px-2 md:px-0 md:max-w-2xl"
+        class="flex w-full flex-col items-center justify-center px-2 md:max-w-2xl md:px-0"
       >
         <div class="flex">
-          <h1 class="text-5xl uppercase mb-1 text-brand">cuely</h1>
+          <h1 class="mb-1 text-5xl uppercase text-brand">cuely</h1>
           <span class="text-gray-500">BETA</span>
         </div>
 

--- a/frontend/src/pages/search.astro
+++ b/frontend/src/pages/search.astro
@@ -11,17 +11,17 @@ import { askama } from "../askama";
 ---
 
 <Layout title="{{ query }} - Cuely">
-  <main class="flex flex-col w-full">
+  <main class="flex w-full flex-col">
     <div class="border-b bg-neutral-50">
       <Header searchbar={{ query: askama`query` }} />
     </div>
 
     <div
-      class="grid sm:px-5 md:pl-20 lg:px-36 mx-1 lg:mx-0 md:gap-x-12 md:grid-cols-[minmax(50ch,48rem)_1fr] md:grid-rows-[auto_1fr] gap-y-6 pt-3 search-content"
+      class="search-content mx-1 grid gap-y-6 pt-3 sm:px-5 md:grid-cols-[minmax(50ch,48rem)_1fr] md:grid-rows-[auto_1fr] md:gap-x-12 md:pl-20 lg:mx-0 lg:px-36"
     >
       <!-- Stats and settings -->
-      <div class="flex w-full justify-between mx-auto">
-        <div class="flex flex-col h-full justify-center text-sm text-gray-600">
+      <div class="mx-auto flex w-full justify-between">
+        <div class="flex h-full flex-col justify-center text-sm text-gray-600">
           <p class="h-fit">
             Found {askama`num_matches $ 24`} results in {
               askama`search_duration_sec $ 0.42s`
@@ -33,12 +33,12 @@ import { askama } from "../askama";
             current_optic_url="current_optic_url"
             default_optics="default_optics"
           />
-          <div class="select-region h-full flex flex-col justify-center">
+          <div class="select-region flex h-full flex-col justify-center">
             <select
               form="searchbar-form"
               name="gl"
               onchange="document.getElementById('searchbar-form').submit()"
-              class="hover:cursor-pointer bg-transparent text-sm border-0 max-w-[100px]"
+              class="max-w-[100px] border-0 bg-transparent text-sm hover:cursor-pointer"
             >
               {
                 askama.for_("region_selection in all_regions", () =>
@@ -62,7 +62,7 @@ import { askama } from "../askama";
       </div>
 
       <!-- Search results -->
-      <div class="col-start-1 flex flex-col max-w-4xl min-w-0 space-y-10">
+      <div class="col-start-1 flex min-w-0 max-w-4xl flex-col space-y-10">
         {
           askama.if_("let Some(correction) = spell_correction", () => (
             <div>
@@ -80,27 +80,34 @@ import { askama } from "../askama";
         {
           askama.for_("item in search_result", () => (
             <div class="flex w-full">
-              <div class="flex grow min-w-0 flex-col space-y-1">
+              <div class="flex min-w-0 grow flex-col space-y-1">
                 <div class="flex min-w-0">
-                  <div class="flex flex-col space-y-1 grow min-w-0">
+                  <div class="flex min-w-0 grow flex-col space-y-1">
                     <div class="flex items-center text-sm">
                       <a
-                        class="text-gray-800 hover:no-underline truncate url"
+                        class="url truncate text-gray-800 hover:no-underline"
                         href="{{ item.url }}"
                       >
                         {askama`item.pretty_url $ {{internet.url}}`}
                       </a>
                     </div>
-                    <a class="title-link truncate text-xl font-medium" title="{{ item.title }}" href="{{ item.url }}">
+                    <a
+                      class="title-link truncate text-xl font-medium"
+                      title="{{ item.title }}"
+                      href="{{ item.url }}"
+                    >
                       {askama`item.title $ {{lorem.sentence}}`}
                     </a>
                   </div>
-                  <div class="adjust-btn min-w-fit hidden justify-center items-center md:flex" data-site="{{ item.site }}">
+                  <div
+                    class="adjust-btn hidden min-w-fit items-center justify-center md:flex"
+                    data-site="{{ item.site }}"
+                  >
                     <Hero class="w-6" icon="adjustments" />
                   </div>
                 </div>
                 <div class="text-sm text-snippet">
-                  <Snippet snippet={askama `item.snippet`} />
+                  <Snippet snippet={askama`item.snippet`} />
                 </div>
               </div>
               <div class="flex h-full w-20 items-center">
@@ -123,7 +130,7 @@ import { askama } from "../askama";
           ))
         }
 
-        <div class="flex w-full justify-center items-center">
+        <div class="flex w-full items-center justify-center">
           {
             askama.if_(
               "let Some(url) = prev_page_url",
@@ -179,7 +186,7 @@ import { askama } from "../askama";
   }
 
   .adjust-btn {
-    @apply text-gray-500/25 hover:text-gray-500 w-5 hover:cursor-pointer;
+    @apply w-5 text-gray-500/25 hover:cursor-pointer hover:text-gray-500;
   }
 
   .adjust-btn * {
@@ -205,20 +212,20 @@ import { askama } from "../askama";
   </style>
 </noscript>
 
-<link rel="stylesheet" href="/css/highlightjs-default.min.css"/>
-<script is:inline src="/js/highlight.min.js" />
+<link rel="stylesheet" href="/css/highlightjs-default.min.css" />
+<script is:inline src="/js/highlight.min.js"></script>
 <script is:inline>
   var rankingAdjustButtons = document.querySelectorAll(".adjust-btn");
   var rankingModal = document.getElementById("ranking-modal");
 
   document.addEventListener("click", (elem) => {
-      rankingModal.classList.remove("modal-open");
-      rankingModal.classList.add("modal-closed");
-  })
+    rankingModal.classList.remove("modal-open");
+    rankingModal.classList.add("modal-closed");
+  });
 
   var rankingModalHeight = rankingModal.clientHeight;
 
-  rankingAdjustButtons.forEach(btn => {
+  rankingAdjustButtons.forEach((btn) => {
     btn.addEventListener("click", (event) => {
       event.stopPropagation();
 
@@ -227,14 +234,20 @@ import { askama } from "../askama";
       updateModal(elem.dataset.site);
 
       const rect = elem.getBoundingClientRect();
-      rankingModal.style.left = rect.left + rect.width + 5 +"px";
-      rankingModal.style.top = (rect.top + document.documentElement.scrollTop - (rankingModalHeight/2)) + "px";
+      rankingModal.style.left = rect.left + rect.width + 5 + "px";
+      rankingModal.style.top =
+        rect.top +
+        document.documentElement.scrollTop -
+        rankingModalHeight / 2 +
+        "px";
 
       setTimeout(() => {
         rankingModal.classList.remove("modal-closed");
         rankingModal.classList.add("modal-open");
       }, 0);
-    })
+    });
   });
 </script>
-<script is:inline>hljs.highlightAll();</script>
+<script is:inline>
+  hljs.highlightAll();
+</script>

--- a/frontend/src/pages/settings/index.astro
+++ b/frontend/src/pages/settings/index.astro
@@ -7,40 +7,40 @@ import { askama } from "../../askama";
 ---
 
 <Layout title="Cuely">
-  <div class="flex flex-col h-full w-full">
+  <div class="flex h-full w-full flex-col">
     <Header />
 
-    <div class="flex w-full h-fit justify-center pt-10">
+    <div class="flex h-fit w-full justify-center pt-10">
       <SettingsMenu />
-      <div class="flex flex-col max-w-2xl">
-        <h1 class="font-medium text-2xl">Manage Optics</h1>
-        <div class="text-sm mt-5">
+      <div class="flex max-w-2xl flex-col">
+        <h1 class="text-2xl font-medium">Manage Optics</h1>
+        <div class="mt-5 text-sm">
           Optics lets you control almost everything about which search results
           that gets returned to you. You can discard results from specific
           sites, boost results from other sites and much more.
         </div>
-        <div class="text-sm mt-3">
+        <div class="mt-3 text-sm">
           See our <a
             href="https://github.com/Cuely/sample-optics/blob/main/quickstart.optic"
             >quickstart</a
-          > for how to get started. Once you have developed your optic, you can
-          add it here to be used during your search.
+          > for how to get started. Once you have developed your optic, you can add
+          it here to be used during your search.
         </div>
-        <div class="text-sm mt-3">
-          Simply host the optic on a url that returns a plain-text HTTP
-          response with the optic. We use raw.githubusercontent.com, but you
-          are free to host them elsewhere.
+        <div class="mt-3 text-sm">
+          Simply host the optic on a url that returns a plain-text HTTP response
+          with the optic. We use raw.githubusercontent.com, but you are free to
+          host them elsewhere.
         </div>
         <div
           class="mt-16"
           x-data="{ items: $persist([]).as('optics'), name: '', url: '' }"
         >
-          <div class="w-full flex justify-between pl-5 pr-5">
+          <div class="flex w-full justify-between pl-5 pr-5">
             <input id="name" type="text" placeholder="Name" x-model="name" />
             <input id="url" type="text" placeholder="Url" x-model="url" />
             <button
               x-on:click="items.push({ name, url }); name = url = ''"
-              class="bg-brand text-white rounded-full w-20 h-10 border-0 text-sm"
+              class="h-10 w-20 rounded-full border-0 bg-brand text-sm text-white"
               >Add</button
             >
           </div>
@@ -48,8 +48,8 @@ import { askama } from "../../askama";
             <div class="grid w-full space-y-5" id="optics-list">
               <div class="flex">
                 <div class="w-10"></div>
-                <div class="font-medium flex-1">Name</div>
-                <div class="font-medium flex-1">Url</div>
+                <div class="flex-1 font-medium">Name</div>
+                <div class="flex-1 font-medium">Url</div>
               </div>
               {
                 askama.for_("optic in default_optics", () => (
@@ -67,7 +67,7 @@ import { askama } from "../../askama";
                   <div class="w-10">
                     <img
                       src="/images/delete.svg"
-                      class="w-5 h-5 hover:cursor-pointer"
+                      class="h-5 w-5 hover:cursor-pointer"
                       x-on:click="items.splice(index, 1)"
                     />
                   </div>

--- a/frontend/src/pages/settings/sites.astro
+++ b/frontend/src/pages/settings/sites.astro
@@ -6,21 +6,21 @@ import SettingsMenu from "../../components/SettingsMenu.astro";
 ---
 
 <Layout title="Cuely">
-  <div class="flex flex-col h-full w-full">
+  <div class="flex h-full w-full flex-col">
     <Header />
 
-    <div class="flex w-full h-fit justify-center pt-10">
+    <div class="flex h-fit w-full justify-center pt-10">
       <SettingsMenu />
-      <div class="flex w-full flex-col max-w-2xl space-y-10">
+      <div class="flex w-full max-w-2xl flex-col space-y-10">
         <div>
-          <h1 class="font-medium text-2xl mb-2">Liked Sites</h1>
+          <h1 class="mb-2 text-2xl font-medium">Liked Sites</h1>
           <div class="text-sm">
             These sites receive a boost during search. Results from these sites
             are more likely to appear in your search results.
           </div>
           <div class="mt-5">
             <div
-              class="grid grid-cols-[auto_1fr] w-full space-y-5"
+              class="grid w-full grid-cols-[auto_1fr] space-y-5"
               id="liked-list"
             >
               <div class="w-10"></div>
@@ -30,14 +30,14 @@ import SettingsMenu from "../../components/SettingsMenu.astro";
         </div>
 
         <div>
-          <h1 class="font-medium text-2xl mb-2">Disliked Sites</h1>
+          <h1 class="mb-2 text-2xl font-medium">Disliked Sites</h1>
           <div class="text-sm">
             These sites get de-prioritized during search. Results from these
             sites are less likely to appear in your search results.
           </div>
           <div class="mt-5">
             <div
-              class="grid grid-cols-[auto_1fr] w-full space-y-5"
+              class="grid w-full grid-cols-[auto_1fr] space-y-5"
               id="disliked-list"
             >
               <div class="w-10"></div>
@@ -47,14 +47,14 @@ import SettingsMenu from "../../components/SettingsMenu.astro";
         </div>
 
         <div>
-          <h1 class="font-medium text-2xl mb-2">Blocked Sites</h1>
+          <h1 class="mb-2 text-2xl font-medium">Blocked Sites</h1>
           <div class="text-sm">
             These are the sites you have blocked. They won't appear in any of
             your searches.
           </div>
           <div class="mt-5">
             <div
-              class="grid grid-cols-[auto_1fr] w-full space-y-5"
+              class="grid w-full grid-cols-[auto_1fr] space-y-5"
               id="blocked-list"
             >
               <div class="w-10"></div>


### PR DESCRIPTION
Since the last version of some of the prettier packages, a lot of bugs regarding tailwind class sorting, and astro formatting in general has been fixed!

This means that the formatters are now more compatible, and no longer produces bogos outputs when formatting certain nested structures.

This commit also adds a npm script (`npm run prettier`) for formatting all frontend files, and should now produce the same formatting as when saving/formatting in vscode.

Also, some of the packages have bumped quite a few minor version numbers so other improvements might also be included!
(And hopefully no regressions 🤞)